### PR TITLE
Updating the Mantine Color Scheme to Auto

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,7 @@ const theme = createTheme({
 
 export default function App({ Component, pageProps }: AppProps) {
     return (
-        <MantineProvider theme={theme}>
+        <MantineProvider defaultColorScheme="auto" theme={theme}>
             <Component {...pageProps} />
         </MantineProvider>
     );


### PR DESCRIPTION
Updating the Mantine Color Scheme to Auto.

On dark mode devices it will be dark and on light mode devices it will be light!