### PR TITLE
Added explanatory modal

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,10 +3,11 @@ import utilStyles from '../styles/utils.module.css';
 import Link from 'next/link';
 import { GetStaticProps } from 'next';
 import { C19TestData as C19TestData, getSortedTestsData, TestBrandName, TestManufacturer } from '@/lib/covidTests';
-import { AppShell, Button, Container, Group, MantineColorScheme, SegmentedControl, Select, useMantineColorScheme } from '@mantine/core';
+import { AppShell, Button, Container, Group, MantineColorScheme, Modal, SegmentedControl, Select, useMantineColorScheme } from '@mantine/core';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { DatePicker } from '@mantine/dates';
 import { ColorSchemeScript } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 
 
 export default function Home({
@@ -22,6 +23,9 @@ export default function Home({
   const [testBrand, setTestBrand] = useState<TestBrandName | null>(null);
   const [expiration, setExpiration] = useState<string | null>(null);
   const [lotNumber, setLotNumber] = useState<string | null>(null);
+  const [opened, { open, close }] = useDisclosure(false);
+
+
   const newExpirationDate = Array.from(
     new Set(
       c19TestData
@@ -104,7 +108,18 @@ export default function Home({
         </AppShell.Main>
         <AppShell.Footer>
           <ColorSchemeToggle />
+          <Button onClick={open}>About this page</Button>
         </AppShell.Footer>
+
+        <Modal opened={opened} onClose={close} title="About this page">
+          <p>If box expiration date lists just a month and year, use the last day of the month listed (e.g. a test with an expiration date December 2023 on the box has an expiration date 2023-12-31 on this tool) </p>
+          <p>Relevant for Celltrion USA, Inc.: Celltrion DiaTrust COVID-19 Ag Home Test: For lot numbers with (*), if your test has this lot number followed by additional letters, the expiration dates listed also apply. For example, a test with lot number COVSA1001, would have the same manufacture date as lot numbers COVSA1001-A or COVSA1001-HF. Lot numbers COVSA1001-A or COVSA1001-HF would have the same extended expiration date as COVSA1001 in the table above.</p>
+          <p>If a particular test or lot number is not listed, then use the expiration date listed on the box of the test.</p>
+          <p>Data source: <a href="https://www.fda.gov/medical-devices/coronavirus-covid-19-and-medical-devices/home-otc-covid-19-diagnostic-tests#list">Authorized At-Home OTC COVID-19 Diagnostic Tests and Expiration Dates
+ on fda.gov</a> (data retrieved 9/25/2023 by <a href="https://www.linkedin.com/in/jesse-erin-lang/">Jesse Lang, MPA in Health Care Policy</a>)</p>
+
+
+        </Modal>
 
       </AppShell>
     </>


### PR DESCRIPTION
![image](https://github.com/covid-test-dates/covid-test-date-site/assets/201313/1611db46-80d9-46ca-a005-dc058be5697b)
