### PR TITLE
Replacing the Footer with an addition element

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -110,23 +110,19 @@ export default function Home({
                   your test
                 </h2>
               )}
-              <Space h="xl" />
-              <Space h="xl" />
-              <Space h="xl" />
-              <Space h="xl" />
+            </section>
+            <Divider my="xl" />
+            <section>
+                <ColorSchemeToggle />
+                <Group justify="center" mt="sm">
+                  <Button onClick={open} variant="filled">
+                    About this tool
+                  </Button>
+                </Group>
+                <Space h="sm" />
             </section>
           </Container>
         </AppShell.Main>
-        <AppShell.Footer>
-          <ColorSchemeToggle />
-          <Group justify="center" mt="sm">
-            <Button onClick={open} variant="filled">
-              About this tool
-            </Button>
-          </Group>
-          <Space h="sm" />
-        </AppShell.Footer>
-
         <Modal centered opened={opened} onClose={close} title="About this tool">
           <p>Data source: <a href="https://www.fda.gov/medical-devices/coronavirus-covid-19-and-medical-devices/home-otc-covid-19-diagnostic-tests#list">Authorized At-Home OTC COVID-19 Diagnostic Tests and Expiration Dates
             on fda.gov</a></p>


### PR DESCRIPTION
The existing Footer made it hard to use on Mobile, which was an issue.

I replaced it with a regular section.
<img width="1040" alt="image" src="https://github.com/covid-test-dates/covid-test-date-site/assets/3288227/7a86b0e5-bbe7-41e0-930e-21fc410f012a">

On mobile it looks much better:
Before:
<img width="375" alt="image" src="https://github.com/covid-test-dates/covid-test-date-site/assets/3288227/afd50d31-26ab-494c-b32b-81ba69d12c3b">

After:
<img width="377" alt="image" src="https://github.com/covid-test-dates/covid-test-date-site/assets/3288227/920183c0-76ff-462b-8c41-45c040edae3c">
